### PR TITLE
Example changes to the Shell Page Navigation

### DIFF
--- a/Demo UWP/Demo UWP.csproj
+++ b/Demo UWP/Demo UWP.csproj
@@ -97,12 +97,16 @@
     </Compile>
     <Compile Include="ViewModels\FavoritesPageViewModel.cs" />
     <Compile Include="ViewModels\HomePageViewModel.cs" />
+    <Compile Include="ViewModels\Navigation\ShellPageNavigationItemViewModel.cs" />
     <Compile Include="ViewModels\SettingsPageViewModel.cs" />
     <Compile Include="Views\FavoritesPage.xaml.cs">
       <DependentUpon>FavoritesPage.xaml</DependentUpon>
     </Compile>
     <Compile Include="Views\HomePage.xaml.cs">
       <DependentUpon>HomePage.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Views\Navigation\ShellPageNavigationItemView.xaml.cs">
+      <DependentUpon>ShellPageNavigationItemView.xaml</DependentUpon>
     </Compile>
     <Compile Include="Views\SettingsPage.xaml.cs">
       <DependentUpon>SettingsPage.xaml</DependentUpon>
@@ -139,6 +143,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Views\HomePage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Views\Navigation\ShellPageNavigationItemView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/Demo UWP/ViewModels/Navigation/ShellPageNavigationItemViewModel.cs
+++ b/Demo UWP/ViewModels/Navigation/ShellPageNavigationItemViewModel.cs
@@ -1,0 +1,50 @@
+﻿using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using Windows.UI.Xaml.Controls;
+
+namespace Demo_UWP.ViewModels.Navigation
+{
+    
+    public class ShellPageNavigationItemViewModel : INotifyPropertyChanged
+    {
+        private string _tag;
+        private string _text;
+        private Symbol _glyph;
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        public string Tag
+        {
+            get { return _tag; }
+            set
+            {
+                _tag = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public string Text
+        {
+            get { return _text; }
+            set
+            {
+                _text = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public Symbol Glyph
+        {
+            get { return _glyph; }
+            set
+            {
+                _glyph = value;
+                OnPropertyChanged();
+            }
+        }
+
+        protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/Demo UWP/ViewModels/ShellPageViewModel.cs
+++ b/Demo UWP/ViewModels/ShellPageViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -7,6 +8,7 @@ using System.Threading.Tasks;
 using Windows.UI.Xaml.Controls;
 
 using Caliburn.Micro;
+using Demo_UWP.ViewModels.Navigation;
 
 namespace Demo_UWP.ViewModels
 {
@@ -15,10 +17,43 @@ namespace Demo_UWP.ViewModels
         private readonly WinRTContainer _container;
         private readonly IEventAggregator _eventAggregator;
         private INavigationService _navigationService;
+        private ObservableCollection<ShellPageNavigationItemViewModel> _mainNavigationItems;
+        private ShellPageNavigationItemViewModel _selectedMainNavigationItem;
+
+        public ObservableCollection<ShellPageNavigationItemViewModel> MainNavigationItems
+        {
+            get { return _mainNavigationItems; }
+            set
+            {
+                _mainNavigationItems = value;
+                NotifyOfPropertyChange();
+            }
+        }
+
+        public ShellPageNavigationItemViewModel SelectedMainNavigationItem
+        {
+            get { return _selectedMainNavigationItem; }
+            set
+            {
+                _selectedMainNavigationItem = value;
+                NotifyOfPropertyChange();
+            }
+        }
+
         public ShellPageViewModel(WinRTContainer container, IEventAggregator eventAggregator)
         {
             _container = container;
             _eventAggregator = eventAggregator;
+        }
+
+        protected override void OnActivate()
+        {
+            MainNavigationItems = new BindableCollection<ShellPageNavigationItemViewModel>
+            {
+                new ShellPageNavigationItemViewModel { Tag = "Home", Text = "Home", Glyph = Symbol.Home },
+                new ShellPageNavigationItemViewModel { Tag = "Favorites", Text = "Favorites", Glyph = Symbol.OutlineStar },
+                new ShellPageNavigationItemViewModel { Tag = "Settings", Text = "Settings", Glyph = Symbol.Setting }
+            };
         }
 
         public void SetupNavigationService(Frame frame)
@@ -29,7 +64,22 @@ namespace Demo_UWP.ViewModels
             _navigationService = _container.RegisterNavigationService(frame);
         }
 
-        public void MenuItemSelected(ListBoxItem item)
+        /* 
+         * @erik - you had this strongly-typed as a ListBoxItem
+         * Caliburn was trying to pass in the associated ViewModel, not the UI item.
+         * 
+         * You can manipulate what item is passed into this method by setting different things 
+         * in the Message.Attach declaration in the XAML
+         * 
+         * This page will enumerate the options for you and is an all-around handy guide to Caliburn.Micro:
+         * http://caliburnmicro.codeplex.com/wikipage?title=Cheat%20Sheet&referringTitle=Documentation
+         * 
+         * As a troubleshooting tip in the future, when you get a null in one of these types of method calls again,
+         * try changing the parameter type to "object" and then inspect it at runtime.  A null generally
+         * means a bad cast was attempted.
+         * 
+        */
+        public void MenuItemSelected(ShellPageNavigationItemViewModel item)
         {
             switch (item.Tag.ToString())
             {

--- a/Demo UWP/Views/Navigation/ShellPageNavigationItemView.xaml
+++ b/Demo UWP/Views/Navigation/ShellPageNavigationItemView.xaml
@@ -1,0 +1,16 @@
+﻿<UserControl
+    x:Class="Demo_UWP.Views.Navigation.ShellPageNavigationItemView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Demo_UWP.Views.Navigation"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+    <StackPanel Orientation="Horizontal">
+        <SymbolIcon Symbol="{Binding Glyph}" Width="27" Height="27" />
+        <TextBlock x:Name="Text" FontSize="18" VerticalAlignment="Center" Margin="10 0 0 0" />
+    </StackPanel>
+</UserControl>

--- a/Demo UWP/Views/Navigation/ShellPageNavigationItemView.xaml.cs
+++ b/Demo UWP/Views/Navigation/ShellPageNavigationItemView.xaml.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at http://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace Demo_UWP.Views.Navigation
+{
+    public sealed partial class ShellPageNavigationItemView : UserControl
+    {
+        public ShellPageNavigationItemView()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/Demo UWP/Views/ShellPage.xaml
+++ b/Demo UWP/Views/ShellPage.xaml
@@ -13,28 +13,7 @@
             <StackPanel>
                 <Button x:Name="HamburgerButton" FontFamily="{ThemeResource SymbolThemeFontFamily}" Content="&#xE700;"
                     Width="50" Height="50" Background="Transparent" Click="HamburgerButton_Click" />
-                <ListBox cm:Message.Attach="[Event SelectionChanged] = [MenuItemSelected($this)]">
-                    <ListBox.Items>
-                        <ListBoxItem Tag="Home">
-                            <StackPanel Orientation="Horizontal">
-                                <FontIcon Glyph="&#xE10F;" Width="27" Height="27" />
-                                <TextBlock Text="Home" FontSize="18" VerticalAlignment="Center" Margin="10 0 0 0" />
-                            </StackPanel>
-                        </ListBoxItem>
-                        <ListBoxItem Tag="Favorites">
-                            <StackPanel Orientation="Horizontal">
-                                <FontIcon Glyph="&#xE734;" Width="27" Height="27" />
-                                <TextBlock Text="Favorites" FontSize="18" VerticalAlignment="Center" Margin="10 0 0 0" />
-                            </StackPanel>
-                        </ListBoxItem>
-                        <ListBoxItem Tag="Settings">
-                            <StackPanel Orientation="Horizontal">
-                                <FontIcon Glyph="&#xE713;" Width="27" Height="27" />
-                                <TextBlock Text="Settings" FontSize="18" VerticalAlignment="Center" Margin="10 0 0 0" />
-                            </StackPanel>
-                        </ListBoxItem>
-                    </ListBox.Items>
-                </ListBox>
+                <ListBox x:Name="MainNavigationItems" cm:Message.Attach="[Event SelectionChanged] = [MenuItemSelected($this)]" />
             </StackPanel>
         </SplitView.Pane>
         <SplitView.Content>


### PR DESCRIPTION
Here's an example of an implementation of this that more closely follows a "Caliburn.Micro way" of thinking.
- Removed the hard-coded ListBoxItem XAML definitions
- Added a ViewModel representation of the Navigation control data structure
- Added a View representation of the Navigation control display
- Created the 2 properties necessary on the ShellPageViewModel to support both a collection of Navigation Items and the Selected Item for that collection
- Updated the Shell Page View's ListBox to use the Caliburn.Micro "x:Name={}" syntax, which hooks up the collection/selected properties in the view model
- Overrode the OnActivate placeholder method to setup the page and create the Navigation Item view models

Note: By default Caliburn.Micro is ViewModel-first, so it auto-determines the view to use based upon the ViewModel type.  That why I can get away with just declaring a collection of ShellPageNavigationItemViewModel items and it properly find the views for them with no body declaration in the XAML ListBox.
